### PR TITLE
FLOW-4100 Improve detecting of table primary key

### DIFF
--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeDBOperations.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeDBOperations.cs
@@ -65,10 +65,9 @@ namespace SnowflakeV2CoreLogic.Providers
             SnowflakeTableData? primaryKeyResponse = null;
             using (var latencyLogger = new LatencyLogger(Constants.GetObjectAsync, logger))
             {
-                var primaryKeyStatement = $"WITH t AS (select get_ddl(?,?) tbl_ddl), t1 AS (SELECT POSITION('primary key (', tbl_ddl) + 13 pos, SUBSTR(tbl_ddl, pos, POSITION(')', tbl_ddl, pos) - pos ) str FROM t) SELECT x.value column_name, x.index ordinal_position FROM t1, LATERAL SPLIT_TO_TABLE(t1.str, ',') x;";
+                var primaryKeyStatement = $"SHOW PRIMARY KEYS IN IDENTIFIER(?);";
                 var primaryKeyBindings = new SnowflakeRequestBindings();
-                primaryKeyBindings.AddTextBinding(1, "TABLE");
-                primaryKeyBindings.AddTextBinding(2, tableName);
+                primaryKeyBindings.AddTextBinding(1, tableName);
 
                 primaryKeyResponse = await snowflakeClient.CallAPIAsync(httpClient, primaryKeyStatement, primaryKeyBindings, connectionParameters).ConfigureAwait(true);
             }
@@ -394,7 +393,7 @@ namespace SnowflakeV2CoreLogic.Providers
             return data;
         }
 
-        internal async Task<SnowflakeTableData> GetInformationScehmaAsync(
+        internal async Task<SnowflakeTableData> GetInformationSchemaAsync(
             SnowflakeConnectionParameters connectionParameters)
         {
             string role = connectionParameters.Role;

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeTableDataProvider.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeTableDataProvider.cs
@@ -129,7 +129,7 @@ namespace SnowflakeV2CoreLogic.Providers
             try
             {
                 // Grab the first element and look for the column_name property, which will have a value that aligns to the primary key column name.
-                primaryKeyColumn = primaryKeyData?.ToGenericDictionaryList()[0]["COLUMN_NAME"].ToString();
+                primaryKeyColumn = primaryKeyData?.ToGenericDictionaryList()[0]["column_name"].ToString();
             }
             catch (Exception)
             {
@@ -218,7 +218,7 @@ namespace SnowflakeV2CoreLogic.Providers
             try
             {
                 // Grab the first element and look for the column_name property, which will have a value that aligns to the primary key column name.
-                primaryKeyColumn = primaryKeyData?.ToGenericDictionaryList()[0]["COLUMN_NAME"].ToString();
+                primaryKeyColumn = primaryKeyData?.ToGenericDictionaryList()[0]["column_name"].ToString();
             }
             catch (Exception)
             {
@@ -275,7 +275,7 @@ namespace SnowflakeV2CoreLogic.Providers
             try
             {
                 // Grab the first element and look for the column_name property, which will have a value that aligns to the primary key column name.
-                primaryKeyColumn = primaryKeyData?.ToGenericDictionaryList()[0]["COLUMN_NAME"].ToString();
+                primaryKeyColumn = primaryKeyData?.ToGenericDictionaryList()[0]["column_name"].ToString();
             }
             catch (Exception)
             {

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeTestConnectionProvider.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeTestConnectionProvider.cs
@@ -55,7 +55,7 @@ namespace SnowflakeV2CoreLogic.Providers
                 }
 
                 // Try and query the schema table for Serivce Principal auth
-                await snowflakeDBOperations.GetInformationScehmaAsync(connParam).ConfigureAwait(true);
+                await snowflakeDBOperations.GetInformationSchemaAsync(connParam).ConfigureAwait(true);
 
                 logger.LogInformation("Test connection succeeded");
                 return new HttpResponseMessage(HttpStatusCode.OK);


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [ ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [ ] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ ] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ ] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


