### PR TITLE
FLOW-9610 Add support for tolower and toupper functions

### DIFF
--- a/certified-connectors/Snowflake v2/SnowflakeTestApp.Tests/Data/TableDataEndpointIntegrationTest.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeTestApp.Tests/Data/TableDataEndpointIntegrationTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -315,6 +315,54 @@ namespace SnowflakeTestApp.Tests.Data
             Assert.IsTrue(inactiveData.Value.Count > 0, $"Should return some inactive records");
             
             Assert.IsTrue(inactiveData.Value.All(item => !item.IsActive), "All filtered records should be inactive");
+        }
+
+        /// <summary>
+        /// Test that tolower() enables case-insensitive filtering.
+        /// Seeded data has "John Doe" (mixed case). A plain eq with lowercase should return nothing
+        /// because Snowflake is case-sensitive by default, but tolower(NAME) eq 'john doe' should match.
+        /// </summary>
+        [TestMethod]
+        public async Task GetItemsEndpoint_FilterWithToLower_ReturnsCaseInsensitiveMatch()
+        {
+            var testToken = GetTestToken();
+            HttpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {testToken}");
+            HttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            var caseSensitiveResponse = await HttpClient.GetAsync(
+                $"{BaseUrl}/datasets('{TestDataset}')/tables('{TestTable}')/items?$filter=NAME eq 'john doe'");
+            Assert.AreEqual(HttpStatusCode.OK, caseSensitiveResponse.StatusCode, "Case-sensitive filter request should succeed");
+
+            var caseSensitiveContent = await caseSensitiveResponse.Content.ReadAsStringAsync();
+            var caseSensitiveData = JsonConvert.DeserializeObject<ODataResponse<TestDataRecord>>(caseSensitiveContent);
+            Assert.IsNotNull(caseSensitiveData?.Value, "Case-sensitive filter response should be parseable");
+            Assert.AreEqual(0, caseSensitiveData.Value.Count,
+                "Plain eq with lowercase 'john doe' should return no results because Snowflake is case-sensitive");
+
+            var toLowerResponse = await HttpClient.GetAsync(
+                $"{BaseUrl}/datasets('{TestDataset}')/tables('{TestTable}')/items?$filter=tolower(NAME) eq 'john doe'");
+            Assert.AreEqual(HttpStatusCode.OK, toLowerResponse.StatusCode, "tolower filter request should succeed");
+
+            var toLowerContent = await toLowerResponse.Content.ReadAsStringAsync();
+            var toLowerData = JsonConvert.DeserializeObject<ODataResponse<TestDataRecord>>(toLowerContent);
+            Assert.IsNotNull(toLowerData?.Value, "tolower filter response should contain data");
+            Assert.IsTrue(toLowerData.Value.Count > 0, "tolower(NAME) eq 'john doe' should return at least one record");
+            Assert.IsTrue(
+                toLowerData.Value.All(item => item.Name.Equals("John Doe")),
+                "All returned records should have NAME matching 'John Doe'");
+
+            var bothSidesResponse = await HttpClient.GetAsync(
+                $"{BaseUrl}/datasets('{TestDataset}')/tables('{TestTable}')/items?$filter=tolower(NAME) eq tolower('jOhN DOe')");
+            Assert.AreEqual(HttpStatusCode.OK, bothSidesResponse.StatusCode, "tolower on both sides should succeed");
+
+            var bothSidesContent = await bothSidesResponse.Content.ReadAsStringAsync();
+            var bothSidesData = JsonConvert.DeserializeObject<ODataResponse<TestDataRecord>>(bothSidesContent);
+            Assert.IsNotNull(bothSidesData?.Value, "tolower both-sides response should contain data");
+            Assert.IsTrue(bothSidesData.Value.Count > 0,
+                "tolower(NAME) eq tolower('jOhN DOe') should return at least one record");
+            Assert.IsTrue(
+                bothSidesData.Value.All(item => item.Name.Equals("John Doe")),
+                "All returned records should have NAME matching 'John Doe'");
         }
 
         /// <summary>

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Utilities/ODataToSqlParser.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Utilities/ODataToSqlParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 namespace SnowflakeV2CoreLogic.Utilities
@@ -30,6 +30,8 @@ namespace SnowflakeV2CoreLogic.Utilities
     /// - contains(property, value): Checks if property contains the specified value
     /// - startswith(property, value): Checks if property starts with the specified value
     /// - endswith(property, value): Checks if property ends with the specified value
+    /// - tolower(expression): Converts the expression to lowercase
+    /// - toupper(expression): Converts the expression to uppercase
     /// 
     /// </summary>
     public class ODataToSqlParser
@@ -162,6 +164,24 @@ namespace SnowflakeV2CoreLogic.Utilities
                     value = value.Substring(1, value.Length - 2);
 
                 return $"{property} LIKE '%{value}'";
+            }
+            else if (functionCallNode.Name.Equals("tolower", StringComparison.OrdinalIgnoreCase))
+            {
+                var arguments = functionCallNode.Parameters.ToList();
+                if (arguments.Count != 1)
+                    throw new InvalidOperationException("tolower function requires exactly one argument");
+
+                var operand = ParseExpression(arguments[0] as SingleValueNode);
+                return $"LOWER({operand})";
+            }
+            else if (functionCallNode.Name.Equals("toupper", StringComparison.OrdinalIgnoreCase))
+            {
+                var arguments = functionCallNode.Parameters.ToList();
+                if (arguments.Count != 1)
+                    throw new InvalidOperationException("toupper function requires exactly one argument");
+
+                var operand = ParseExpression(arguments[0] as SingleValueNode);
+                return $"UPPER({operand})";
             }
 
             throw new NotSupportedException($"Unsupported function: {functionCallNode.Name}");

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogicTests/Utilities/ODataToSqlParserTest.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogicTests/Utilities/ODataToSqlParserTest.cs
@@ -238,7 +238,7 @@ namespace SnowflakeV2CoreLogic.Tests.Utilities
             var propertyNode = new SingleValueOpenPropertyAccessNode(
                 new ConstantNode("dummy"), "Name");
             var functionNode = new SingleValueFunctionCallNode(
-                "tolower",
+                "trim",
                 new QueryNode[] { propertyNode },
                 EdmCoreModel.Instance.GetString(false));
             var filterClause = MakeFilterClause(functionNode);
@@ -275,6 +275,58 @@ namespace SnowflakeV2CoreLogic.Tests.Utilities
 
             var result = parser.ParseFilterToSql(filterClause);
             Assert.AreEqual("Age = 42", result);
+        }
+
+        #endregion
+
+        #region 9. tolower / toupper
+
+        [TestMethod]
+        public void ParseFilterToSql_ToLower_OnColumn()
+        {
+            var filter = ParseFilter("tolower(Name) eq 'alice'");
+            var result = parser.ParseFilterToSql(filter);
+            Assert.AreEqual("LOWER(Name) = 'alice'", result);
+        }
+
+        [TestMethod]
+        public void ParseFilterToSql_ToUpper_OnColumn()
+        {
+            var filter = ParseFilter("toupper(Name) eq 'ALICE'");
+            var result = parser.ParseFilterToSql(filter);
+            Assert.AreEqual("UPPER(Name) = 'ALICE'", result);
+        }
+
+        [TestMethod]
+        public void ParseFilterToSql_ToLower_BothSides()
+        {
+            var filter = ParseFilter("tolower(Name) eq tolower('Alice')");
+            var result = parser.ParseFilterToSql(filter);
+            Assert.AreEqual("LOWER(Name) = LOWER('Alice')", result);
+        }
+
+        [TestMethod]
+        public void ParseFilterToSql_ToUpper_BothSides()
+        {
+            var filter = ParseFilter("toupper(Name) eq toupper('Alice')");
+            var result = parser.ParseFilterToSql(filter);
+            Assert.AreEqual("UPPER(Name) = UPPER('Alice')", result);
+        }
+
+        [TestMethod]
+        public void ParseFilterToSql_ToLower_WithContains()
+        {
+            var filter = ParseFilter("contains(tolower(Name), 'ali')");
+            var result = parser.ParseFilterToSql(filter);
+            Assert.AreEqual("LOWER(Name) LIKE '%ali%'", result);
+        }
+
+        [TestMethod]
+        public void ParseFilterToSql_ToLower_CombinedWithAnd()
+        {
+            var filter = ParseFilter("tolower(Name) eq 'alice' and Age gt 25");
+            var result = parser.ParseFilterToSql(filter);
+            Assert.AreEqual("(LOWER(Name) = 'alice') AND (Age > 25)", result);
         }
 
         #endregion


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [X] I attest that the connector works and I verified by deploying and testing all the operations. 
- [X] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [X] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [X] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [X] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


