### PR TITLE
FLOW-5429 Fix NPE on insert/update with NULL column value

### DIFF
--- a/certified-connectors/Snowflake v2/SnowflakeTestApp.Tests/Data/TableDataEndpointIntegrationTest.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeTestApp.Tests/Data/TableDataEndpointIntegrationTest.cs
@@ -490,6 +490,122 @@ namespace SnowflakeTestApp.Tests.Data
         }
 
         /// <summary>
+        /// Test inserting a record with null column values via POST.
+        /// </summary>
+        [TestMethod]
+        public async Task CreateItemEndpoint_WithNullValues_ReturnsCreated()
+        {
+            string createTableSQL = "CREATE OR REPLACE TABLE NULL_INSERT_TEST (" +
+                                    "  ID NUMBER(38,0) NOT NULL," +
+                                    "  NAME VARCHAR(16777216) NOT NULL," +
+                                    "  DESCRIPTION VARCHAR(16777216)," +
+                                    "  SCORE NUMBER(38,0)," +
+                                    "  PRIMARY KEY (ID)" +
+                                    ");";
+            DataSeeder.ExecuteSqlStatement(createTableSQL).GetAwaiter().GetResult();
+
+            var testToken = GetTestToken();
+            HttpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {testToken}");
+            HttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            var newItem = new
+            {
+                ID = 1,
+                NAME = "NullInsertTest",
+                DESCRIPTION = (string) null,
+                SCORE = (int?) null
+            };
+
+            var response = await HttpClient.PostAsync(
+                $"{BaseUrl}/datasets('{TestDataset}')/tables('NULL_INSERT_TEST')/items",
+                CreateJsonContent(newItem));
+
+            Assert.AreEqual(HttpStatusCode.Created, response.StatusCode,
+                "POST with null column values should succeed");
+
+            var readResponse = await HttpClient.GetAsync(
+                $"{BaseUrl}/datasets('{TestDataset}')/tables('NULL_INSERT_TEST')/items('1')");
+            Assert.AreEqual(HttpStatusCode.OK, readResponse.StatusCode);
+
+            var content = await readResponse.Content.ReadAsStringAsync();
+            var record = JObject.Parse(content);
+
+            Assert.AreEqual(1, (int) record["ID"]);
+            Assert.AreEqual("NullInsertTest", (string) record["NAME"]);
+            Assert.IsTrue(record["DESCRIPTION"].Type == JTokenType.Null,
+                "DESCRIPTION should be null in the created record");
+            Assert.IsTrue(record["SCORE"].Type == JTokenType.Null,
+                "SCORE should be null in the created record");
+        }
+
+        /// <summary>
+        /// Test updating an existing column to null via PUT.
+        /// </summary>
+        [TestMethod]
+        public async Task UpdateItemEndpoint_WithNullValue_ReturnsOk()
+        {
+            string createTableSQL = "CREATE OR REPLACE TABLE NULL_UPDATE_TEST (" +
+                                    "  ID NUMBER(38,0) NOT NULL," +
+                                    "  NAME VARCHAR(16777216) NOT NULL," +
+                                    "  DESCRIPTION VARCHAR(16777216)," +
+                                    "  SCORE NUMBER(38,0)," +
+                                    "  PRIMARY KEY (ID)" +
+                                    ");";
+            DataSeeder.ExecuteSqlStatement(createTableSQL).GetAwaiter().GetResult();
+
+            string insertSQL = "INSERT INTO DATAVERSE.PUBLIC.NULL_UPDATE_TEST(ID, NAME, DESCRIPTION, SCORE) " +
+                               "VALUES(1, 'Original', 'Has a description', 42);";
+            DataSeeder.ExecuteSqlStatement(insertSQL).GetAwaiter().GetResult();
+
+            var testToken = GetTestToken();
+            HttpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {testToken}");
+            HttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            // Verify the record exists with non-null values first
+            var beforeResponse = await HttpClient.GetAsync(
+                $"{BaseUrl}/datasets('{TestDataset}')/tables('NULL_UPDATE_TEST')/items('1')");
+            Assert.AreEqual(HttpStatusCode.OK, beforeResponse.StatusCode);
+
+            var beforeContent = await beforeResponse.Content.ReadAsStringAsync();
+            var beforeRecord = JObject.Parse(beforeContent);
+            Assert.AreEqual("Has a description", (string) beforeRecord["DESCRIPTION"],
+                "DESCRIPTION should initially be non-null");
+            Assert.AreEqual(42, (int) beforeRecord["SCORE"],
+                "SCORE should initially be 42");
+
+            // Update: set DESCRIPTION and SCORE to null
+            var updatedItem = new
+            {
+                ID = 1,
+                NAME = "Original",
+                DESCRIPTION = (string) null,
+                SCORE = (int?) null
+            };
+
+            var updateResponse = await HttpClient.PutAsync(
+                $"{BaseUrl}/datasets('{TestDataset}')/tables('NULL_UPDATE_TEST')/items('1')",
+                CreateJsonContent(updatedItem));
+
+            Assert.AreEqual(HttpStatusCode.OK, updateResponse.StatusCode,
+                "PUT with null column values should succeed");
+
+            // Verify the columns are now null
+            var afterResponse = await HttpClient.GetAsync(
+                $"{BaseUrl}/datasets('{TestDataset}')/tables('NULL_UPDATE_TEST')/items('1')");
+            Assert.AreEqual(HttpStatusCode.OK, afterResponse.StatusCode);
+
+            var afterContent = await afterResponse.Content.ReadAsStringAsync();
+            var afterRecord = JObject.Parse(afterContent);
+
+            Assert.AreEqual(1, (int) afterRecord["ID"]);
+            Assert.AreEqual("Original", (string) afterRecord["NAME"]);
+            Assert.IsTrue(afterRecord["DESCRIPTION"].Type == JTokenType.Null,
+                "DESCRIPTION should be null after update");
+            Assert.IsTrue(afterRecord["SCORE"].Type == JTokenType.Null,
+                "SCORE should be null after update");
+        }
+
+        /// <summary>
         /// Helper method to create JSON content from TestDataRecord
         /// </summary>
         private StringContent CreateJsonContent(TestDataRecord record)

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Models/SnowflakeAPIModels/SnowflakeAPIRequestBody.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Models/SnowflakeAPIModels/SnowflakeAPIRequestBody.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 #nullable enable
@@ -41,6 +41,17 @@ namespace SnowflakeV2CoreLogic.Models.SnowflakeAPIModels
 
         public void AddBinding(int index, object value)
         {
+            if (value == null)
+            {
+                JObject nullBinding = new JObject
+                {
+                    ["type"] = "TEXT",
+                    ["value"] = null,
+                };
+                AddBinding(index, nullBinding);
+                return;
+            }
+
             AddTextBinding(index, value.ToString());
         }
 


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [X] I attest that the connector works and I verified by deploying and testing all the operations. 
- [X] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [X] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [X] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [X] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


