### PR TITLE
FLOW-9590 Fix column leak for tables in other schemas

### DIFF
--- a/certified-connectors/Snowflake v2/SnowflakeTestApp.Tests/Metadata/TableMetadataEndpointIntegrationTest.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeTestApp.Tests/Metadata/TableMetadataEndpointIntegrationTest.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -73,6 +74,77 @@ namespace SnowflakeTestApp.Tests.Metadata
             Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
             var content = await response.Content.ReadAsStringAsync();
             StringAssert.Contains(content, "Table 'INVALID_TABLE' does not exist or not authorized");
+        }
+
+        /// <summary>
+        /// Verifies the metadata endpoint only returns columns from the connection's active schema
+        /// (PUBLIC) and does not leak columns from other schemas that happen to have a table
+        /// with the same name.
+        ///
+        /// Setup:
+        ///   - PUBLIC.DUAL_SCHEMA_TABLE          (ID, P_NAME, P_EMAIL)           — connection schema
+        ///   - SCHEMA_META_OTHER.DUAL_SCHEMA_TABLE (ID, O_LABEL, O_AMOUNT, O_ACTIVE) — other schema
+        ///
+        /// GetTableMetadataAsync filters by TABLE_SCHEMA = [configured schema], so only the
+        /// PUBLIC table's columns should appear in the response.
+        /// </summary>
+        [TestMethod]
+        public async Task GetTableMetadataEndpoint_SameTableInTwoSchemas_ReturnsOnlyConnectionSchemaColumns()
+        {
+            const string tableName = "DUAL_SCHEMA_TABLE";
+            const string connectionSchema = "PUBLIC";
+            const string otherSchema = "DEST7";
+
+            DataSeeder.ExecuteSqlStatement(
+                $"CREATE OR REPLACE TABLE {connectionSchema}.{tableName} (" +
+                "  ID NUMBER(38,0) NOT NULL," +
+                "  P_NAME VARCHAR(200) NOT NULL," +
+                "  P_EMAIL VARCHAR(200)," +
+                "  PRIMARY KEY (ID)" +
+                ")").GetAwaiter().GetResult();
+
+            DataSeeder.ExecuteSqlStatement(
+                $"CREATE OR REPLACE TABLE {otherSchema}.{tableName} (" +
+                "  ID NUMBER(38,0) NOT NULL," +
+                "  O_LABEL VARCHAR(200) NOT NULL," +
+                "  O_AMOUNT NUMBER(10,2)," +
+                "  O_ACTIVE BOOLEAN," +
+                "  PRIMARY KEY (ID)" +
+                ")").GetAwaiter().GetResult();
+
+            var testToken = GetTestToken();
+            HttpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {testToken}");
+
+            var response = await HttpClient.GetAsync(
+                $"{BaseUrl}/$metadata.json/datasets/default/tables/{tableName}");
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+
+            var content = await response.Content.ReadAsStringAsync();
+            var metadata = JsonConvert.DeserializeObject<JObject>(content);
+            var properties = metadata["schema"]["items"]["properties"] as JObject;
+            Assert.IsNotNull(properties, "Metadata response should contain schema.items.properties");
+
+            var columnNames = properties.Properties().Select(p => p.Name).ToList();
+
+            // Only columns from PUBLIC (the connection schema) should be present
+            Assert.IsTrue(columnNames.Contains("ID"),
+                "Should contain ID from PUBLIC schema");
+            Assert.IsTrue(columnNames.Contains("P_NAME"),
+                "Should contain P_NAME from PUBLIC schema");
+            Assert.IsTrue(columnNames.Contains("P_EMAIL"),
+                "Should contain P_EMAIL from PUBLIC schema");
+
+            Assert.AreEqual(3, columnNames.Count,
+                $"Expected exactly 3 columns from PUBLIC schema but got: [{string.Join(", ", columnNames)}]");
+
+            // Columns from table in the other schema must NOT leak through
+            Assert.IsFalse(columnNames.Contains("O_LABEL"),
+                "O_LABEL from SCHEMA_META_OTHER should NOT appear");
+            Assert.IsFalse(columnNames.Contains("O_AMOUNT"),
+                "O_AMOUNT from SCHEMA_META_OTHER should NOT appear");
+            Assert.IsFalse(columnNames.Contains("O_ACTIVE"),
+                "O_ACTIVE from SCHEMA_META_OTHER should NOT appear");
         }
     }
 } 

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeDBOperations.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeDBOperations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 #nullable enable
@@ -46,7 +46,7 @@ namespace SnowflakeV2CoreLogic.Providers
 
             using (var latencyLogger = new LatencyLogger(Constants.GetObjectAsync, logger))
             {
-                var metadataStatement = $"SELECT * FROM information_schema.columns where TABLE_NAME=?";
+                var metadataStatement = $"SELECT * FROM information_schema.columns WHERE TABLE_NAME=? AND TABLE_SCHEMA=CURRENT_SCHEMA()";
 
                 // Add request bindings
                 SnowflakeRequestBindings metaDataBindings = new SnowflakeRequestBindings();


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [ ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [ ] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ ] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ ] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


