### PR TITLE
FLOW-9610 Add configuration parameter for ilike

### DIFF
--- a/certified-connectors/Snowflake v2/ConnectorArtifacts/connector-config-internal.json
+++ b/certified-connectors/Snowflake v2/ConnectorArtifacts/connector-config-internal.json
@@ -221,6 +221,18 @@
                   "required": "true"
                 }
               }
+            },
+            "useCaseInsensitiveFilters": {
+              "type": "bool",
+              "uiDefinition": {
+                "displayName": "Use case-insensitive filters",
+                "description": "When enabled, contains/startswith/endswith filters use case-insensitive matching (Snowflake ILIKE).",
+                "tooltip": "Enable case-insensitive pattern matching for OData string filter functions. Off by default to preserve existing behavior.",
+                "constraints": {
+                  "tabIndex": 6,
+                  "required": "false"
+                }
+              }
             }
           }
         },

--- a/certified-connectors/Snowflake v2/SnowflakeTestApp/Mocks/ConnectionParametersProviderMock.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeTestApp/Mocks/ConnectionParametersProviderMock.cs
@@ -55,6 +55,11 @@ namespace SnowflakeTestApp.Mocks
         /// </summary>
         public static string TestRole = "ACCOUNTADMIN";
 
+        /// <summary>
+        /// When true, contains/startswith/endswith use case-insensitive matching (ILIKE).
+        /// </summary>
+        public static bool TestUseCaseInsensitiveFilters = false;
+
         // ====== MOCK IMPLEMENTATION ======
 
         public T GetProperty<T>(string key)
@@ -82,6 +87,11 @@ namespace SnowflakeTestApp.Mocks
             if (key.Equals(Constants.Schema, StringComparison.OrdinalIgnoreCase))
             {
                 return (T)Convert.ChangeType(TestSchema, typeof(T));
+            }
+
+            if (key.Equals(Constants.UseCaseInsensitiveFilters, StringComparison.OrdinalIgnoreCase))
+            {
+                return (T)Convert.ChangeType(TestUseCaseInsensitiveFilters, typeof(T));
             }
 
             throw new ArgumentException();

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Constants.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Constants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Snowflake Inc.
+// Copyright (c) Snowflake Inc.
 // Licensed under the MIT license.
 
 namespace SnowflakeV2CoreLogic
@@ -103,6 +103,7 @@ namespace SnowflakeV2CoreLogic
         public const string Schema = "schema";
         public const string Warehouse = "warehouse";
         public const string Role = "role";
+        public const string UseCaseInsensitiveFilters = "useCaseInsensitiveFilters";
 
         public const string HeaderApimReferrer = "x-ms-apim-referrer";
 

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Models/SnowflakeConnectionParameters.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Models/SnowflakeConnectionParameters.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 namespace SnowflakeV2CoreLogic.Models
@@ -16,6 +16,8 @@ namespace SnowflakeV2CoreLogic.Models
         public string Warehouse { get; set; } = null;
 
         public string Schema { get; set; } = null;
+
+        public bool UseCaseInsensitiveFilters { get; set; } = false;
 
         public string AuthType { get; set; } = "OAUTH";
 

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeConnectionParametersProvider.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeConnectionParametersProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 namespace SnowflakeV2CoreLogic.Providers
@@ -60,6 +60,11 @@ namespace SnowflakeV2CoreLogic.Providers
             if (connectionParametersProvider.PropertyExists(Constants.Schema))
             {
                 connectionParameters.Schema = connectionParametersProvider.GetProperty<string>(Constants.Schema);
+            }
+
+            if (connectionParametersProvider.PropertyExists(Constants.UseCaseInsensitiveFilters))
+            {
+                connectionParameters.UseCaseInsensitiveFilters = connectionParametersProvider.GetProperty<bool>(Constants.UseCaseInsensitiveFilters);
             }
 
             connectionParameters.AuthenticationType = GetAuthenticationType();

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeDBOperations.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Providers/SnowflakeDBOperations.cs
@@ -162,7 +162,7 @@ namespace SnowflakeV2CoreLogic.Providers
                 orderBy = options.OrderBy != null ? options.OrderBy.RawValue : null;
                 top = queryOptions.IsTopSet ? queryOptions.Top.ToString() : Constants.DefaultNumberOfRowsToReturn.ToString();
                 skip = queryOptions.Skip.ToString();
-                filter = ConvertODataFilterToSql(options);
+                filter = ConvertODataFilterToSql(options, connectionParameters?.UseCaseInsensitiveFilters ?? false);
             }
 
             using (var latencyLogger = new LatencyLogger(Constants.ListAllItemsAsync, logger))
@@ -232,12 +232,12 @@ namespace SnowflakeV2CoreLogic.Providers
             return snowflakeTableData;
         }
 
-        public string ConvertODataFilterToSql(ODataQueryOptions options)
+        public string ConvertODataFilterToSql(ODataQueryOptions options, bool useCaseInsensitiveFilters = false)
         {
             if (options?.Filter != null)
             {
                 var filterClause = options.Filter.FilterClause;
-                var sqlConverter = new ODataToSqlParser();
+                var sqlConverter = new ODataToSqlParser(useCaseInsensitiveFilters);
                 return sqlConverter.ParseFilterToSql(filterClause);
             }
 
@@ -421,7 +421,7 @@ namespace SnowflakeV2CoreLogic.Providers
                 string filterText = string.Empty;
                 if (options.Filter != null)
                 {
-                    filterText = ConvertODataFilterToSql(options);
+                    filterText = ConvertODataFilterToSql(options, connectionParameters?.UseCaseInsensitiveFilters ?? false);
                     query = $"SELECT COUNT(*) FROM {table} WHERE {filterText}";
                 }   
             }

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Utilities/ODataToSqlParser.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogic/Utilities/ODataToSqlParser.cs
@@ -36,6 +36,13 @@ namespace SnowflakeV2CoreLogic.Utilities
     /// </summary>
     public class ODataToSqlParser
     {
+        private readonly bool useCaseInsensitiveFilters;
+
+        public ODataToSqlParser(bool useCaseInsensitiveFilters = false)
+        {
+            this.useCaseInsensitiveFilters = useCaseInsensitiveFilters;
+        }
+
         public string ParseFilterToSql(FilterClause filterClause)
         {
             if (filterClause == null)
@@ -119,6 +126,8 @@ namespace SnowflakeV2CoreLogic.Utilities
 
         private string ParseFunctionCall(SingleValueFunctionCallNode functionCallNode)
         {
+            var likeOperator = useCaseInsensitiveFilters ? "ILIKE" : "LIKE";
+
             if (functionCallNode.Name.Equals("contains", StringComparison.OrdinalIgnoreCase))
             {
                 var arguments = functionCallNode.Parameters.ToList();
@@ -135,7 +144,7 @@ namespace SnowflakeV2CoreLogic.Utilities
                     value = value.Substring(1, value.Length - 2);
                 }
 
-                return $"{property} LIKE '%{value}%'";
+                return $"{property} {likeOperator} '%{value}%'";
             }
             else if (functionCallNode.Name.Equals("startswith", StringComparison.OrdinalIgnoreCase))
             {
@@ -149,7 +158,7 @@ namespace SnowflakeV2CoreLogic.Utilities
                 if (value.StartsWith("'") && value.EndsWith("'"))
                     value = value.Substring(1, value.Length - 2);
 
-                return $"{property} LIKE '{value}%'";
+                return $"{property} {likeOperator} '{value}%'";
             }
             else if (functionCallNode.Name.Equals("endswith", StringComparison.OrdinalIgnoreCase))
             {
@@ -163,7 +172,7 @@ namespace SnowflakeV2CoreLogic.Utilities
                 if (value.StartsWith("'") && value.EndsWith("'"))
                     value = value.Substring(1, value.Length - 2);
 
-                return $"{property} LIKE '%{value}'";
+                return $"{property} {likeOperator} '%{value}'";
             }
             else if (functionCallNode.Name.Equals("tolower", StringComparison.OrdinalIgnoreCase))
             {

--- a/certified-connectors/Snowflake v2/SnowflakeV2CoreLogicTests/Utilities/ODataToSqlParserTest.cs
+++ b/certified-connectors/Snowflake v2/SnowflakeV2CoreLogicTests/Utilities/ODataToSqlParserTest.cs
@@ -330,5 +330,72 @@ namespace SnowflakeV2CoreLogic.Tests.Utilities
         }
 
         #endregion
+
+        #region 10. Case-insensitive mode (ILIKE)
+
+        [TestMethod]
+        public void ParseFilterToSql_CaseInsensitive_Contains()
+        {
+            var ciParser = new ODataToSqlParser(useCaseInsensitiveFilters: true);
+            var filter = ParseFilter("contains(Name, 'Ali')");
+            var result = ciParser.ParseFilterToSql(filter);
+            Assert.AreEqual("Name ILIKE '%Ali%'", result);
+        }
+
+        [TestMethod]
+        public void ParseFilterToSql_CaseInsensitive_StartsWith()
+        {
+            var ciParser = new ODataToSqlParser(useCaseInsensitiveFilters: true);
+            var filter = ParseFilter("startswith(Name, 'Ali')");
+            var result = ciParser.ParseFilterToSql(filter);
+            Assert.AreEqual("Name ILIKE 'Ali%'", result);
+        }
+
+        [TestMethod]
+        public void ParseFilterToSql_CaseInsensitive_EndsWith()
+        {
+            var ciParser = new ODataToSqlParser(useCaseInsensitiveFilters: true);
+            var filter = ParseFilter("endswith(Name, 'ce')");
+            var result = ciParser.ParseFilterToSql(filter);
+            Assert.AreEqual("Name ILIKE '%ce'", result);
+        }
+
+        [TestMethod]
+        public void ParseFilterToSql_CaseInsensitive_ContainsWithAnd()
+        {
+            var ciParser = new ODataToSqlParser(useCaseInsensitiveFilters: true);
+            var filter = ParseFilter("contains(Name, 'Al') and Age gt 25");
+            var result = ciParser.ParseFilterToSql(filter);
+            Assert.AreEqual("(Name ILIKE '%Al%') AND (Age > 25)", result);
+        }
+
+        [TestMethod]
+        public void ParseFilterToSql_CaseInsensitive_DefaultFalse_UsesLike()
+        {
+            var defaultParser = new ODataToSqlParser();
+            var filter = ParseFilter("contains(Name, 'Ali')");
+            var result = defaultParser.ParseFilterToSql(filter);
+            Assert.AreEqual("Name LIKE '%Ali%'", result);
+        }
+
+        [TestMethod]
+        public void ParseFilterToSql_CaseInsensitive_ExplicitFalse_UsesLike()
+        {
+            var csParser = new ODataToSqlParser(useCaseInsensitiveFilters: false);
+            var filter = ParseFilter("contains(Name, 'Ali')");
+            var result = csParser.ParseFilterToSql(filter);
+            Assert.AreEqual("Name LIKE '%Ali%'", result);
+        }
+
+        [TestMethod]
+        public void ParseFilterToSql_CaseInsensitive_EqUnaffected()
+        {
+            var ciParser = new ODataToSqlParser(useCaseInsensitiveFilters: true);
+            var filter = ParseFilter("Name eq 'Alice'");
+            var result = ciParser.ParseFilterToSql(filter);
+            Assert.AreEqual("Name = 'Alice'", result);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [ ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [ ] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ ] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ ] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


